### PR TITLE
API documentation missing content.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,15 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Install numpy libs
+      run: pip install numpy
+
+    - name: Install psutil libs
+      run: pip install psutil
+
+    - name: Install redis libs
+      run: pip install redis
+
     - name: Install Sphinx and RTM theme
       run: pip install sphinx sphinx-rtd-theme
           


### PR DESCRIPTION
`sphinx-build` found the following dependencies were missing:

- `numpy`
- `psutil`
- `redis`

These are now pip installed before generating the docs.