### PR TITLE
Fix types

### DIFF
--- a/src/smax/smax_data_types.py
+++ b/src/smax/smax_data_types.py
@@ -24,23 +24,30 @@ import numpy as np
 # 
 # See the bottom of this file for the SmaxVar version of these maps
 _TYPE_MAP = {
-             'int': int,
-             'integer': int,
+             'int': np.int32,
+             'integer': np.int32,
              'int16': np.int16,
              'int32': np.int32,
              'int64': np.int64,
              'int8': np.int8,
-             'double': float,
-             'float': float,
+             'double': np.float64,
              'float32': np.float32,
              'float64': np.float64,
-             'bool': bool,
              'boolean': bool,
              'str': str,
-             'string': str
+             'string': str,
+             'raw': bytes
              }
 
-_REVERSE_TYPE_MAP = inv_map = {v: k for k, v in _TYPE_MAP.items()}
+# The reverse mapping here relies on overwriting the non-standard
+# SMA-X types with the standard types. 
+_REVERSE_TYPE_MAP = {v: k for k, v in _TYPE_MAP.items()}
+
+# Add standard Python types to the inverse map
+_REVERSE_TYPE_MAP[int] = 'int32'
+_REVERSE_TYPE_MAP[float] = 'float64'
+
+inv_map = _REVERSE_TYPE_MAP
 
 # Legacy Named tuples for smax requests and responses.
 #
@@ -523,18 +530,25 @@ class SmaxBool(UserBool, SmaxVarBase):
 
 # Look up table for SMA-X data type maps
 _SMAX_TYPE_MAP = {
-             'int': SmaxInt,
-             'integer': SmaxInt,
+             'int': SmaxInt32,
+             'integer':SmaxInt32,
              'int16': SmaxInt16,
              'int32': SmaxInt32,
              'int64': SmaxInt64,
              'int8': SmaxInt8,
-             'double' : SmaxFloat,
-             'float': SmaxFloat,
+             'float': SmaxFloat64,
              'float32': SmaxFloat32,
              'float64': SmaxFloat64,
              'str': SmaxStr,
              'string': SmaxStr,
-             'bool': SmaxBool,
              'boolean': SmaxBool}
-_REVERSE_SMAX_TYPE_MAP = inv_smax_map = {v: k for k, v in _SMAX_TYPE_MAP.items()}
+
+# The reverse mapping here relies on overwriting the non-standard
+# SMA-X type reverse maps with the standard types 
+_REVERSE_SMAX_TYPE_MAP = {v: k for k, v in _SMAX_TYPE_MAP.items()}
+
+# Add the SMAX subclasses of standard python types
+_REVERSE_SMAX_TYPE_MAP[SmaxInt] = 'int32'
+_REVERSE_SMAX_TYPE_MAP[SmaxFloat] = 'float64'
+
+inv_smax_map = _REVERSE_SMAX_TYPE_MAP

--- a/src/smax/smax_data_types.py
+++ b/src/smax/smax_data_types.py
@@ -30,6 +30,7 @@ _TYPE_MAP = {
              'int32': np.int32,
              'int64': np.int64,
              'int8': np.int8,
+             'single': np.float32,
              'double': np.float64,
              'float32': np.float32,
              'float64': np.float64,
@@ -126,6 +127,31 @@ class SmaxInt(UserInt, SmaxVarBase):
 
     def __repr__(self):
         return str(int(self))
+        
+    def asdict(self):
+        dic = {'data':self}
+        dic.update(asdict(self))
+        
+        return dic
+        
+# For ints, we can't directly subclass the Python int type as they
+# are unmutable.  
+# So we have to go via an intermediate with an added .__new__ method
+class UserBytes(bytes):
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 0:
+            args = (kwargs.pop('data'),)
+        x = int.__new__(cls, args[0])
+        return x
+        
+@dataclass
+class SmaxBytes(UserBytes, SmaxVarBase):
+    """Class for holding SMA-X raw objects, with their metadata"""
+    data: InitVar[bytes]
+    type: str = field(kw_only=True, default='bytes')
+
+    def __repr__(self):
+        return str(bytes(self))
         
     def asdict(self):
         dic = {'data':self}
@@ -541,7 +567,8 @@ _SMAX_TYPE_MAP = {
              'float64': SmaxFloat64,
              'str': SmaxStr,
              'string': SmaxStr,
-             'boolean': SmaxBool}
+             'boolean': SmaxBool,
+             'raw': SmaxBytes}
 
 # The reverse mapping here relies on overwriting the non-standard
 # SMA-X type reverse maps with the standard types 

--- a/src/smax/smax_redis_client.py
+++ b/src/smax/smax_redis_client.py
@@ -15,7 +15,7 @@ from redis.retry import Retry
 
 from .smax_client import SmaxClient, SmaxData, SmaxInt, SmaxFloat, SmaxBool, SmaxStr, \
         SmaxStrArray, SmaxArray, SmaxStruct, SmaxInt8, SmaxInt16, SmaxInt32, \
-        SmaxInt64, SmaxFloat32, SmaxFloat64, SmaxBool, \
+        SmaxInt64, SmaxFloat32, SmaxFloat64, SmaxBool, SmaxBytes, \
         _TYPE_MAP, _REVERSE_TYPE_MAP, _SMAX_TYPE_MAP, _REVERSE_SMAX_TYPE_MAP, \
         optional_metadata, SmaxConnectionError, SmaxKeyError, SmaxUnderflowWarning, \
         join, normalize_pair, print_smax, print_tree
@@ -415,8 +415,8 @@ class SmaxRedisClient(SmaxClient):
             elif type(a) in _REVERSE_SMAX_TYPE_MAP:
                 type_name = _REVERSE_SMAX_TYPE_MAP[type(a)]
             else:
-                self._logger.warning(f"Did not recognize type {str(type(a))}, storing as string or string array.")
-                type_name = "string"
+                self._logger.warning(f"Did not recognize type {str(type(a))}, storing raw values as bytes.")
+                type_name = "bytes"
 
             # Either convert to a string array, or to an numpy.ndarray
             if python_type is list or python_type is tuple or python_type is SmaxStrArray:
@@ -471,8 +471,8 @@ class SmaxRedisClient(SmaxClient):
                 return converted_data, type_name, size
         # Single value of an unknown type
         else:
-            self._logger.warning(f"Did not recognize type {str(type(value))}, storing as string.")
-            type_name = "string"
+            self._logger.warning(f"Did not recognize type {str(type(value))}, storing as bytes.")
+            type_name = "raw"
             return str(value), type_name, 1
 
     def _recurse_nested_dict(self, dictionary):

--- a/tests/test_smax_data_types.py
+++ b/tests/test_smax_data_types.py
@@ -6,8 +6,395 @@ import numpy as np
 
 from smax.smax_data_types import SmaxData, \
     SmaxFloat, SmaxFloat32, SmaxFloat64, SmaxInt, SmaxInt8, SmaxInt16, SmaxInt32, SmaxInt64, \
-    SmaxBool, SmaxArray, SmaxStr, SmaxStrArray, SmaxStruct
+    SmaxBool, SmaxArray, SmaxStr, SmaxStrArray, SmaxBytes, SmaxStruct, \
+    _TYPE_MAP, _REVERSE_TYPE_MAP, _SMAX_TYPE_MAP, _REVERSE_SMAX_TYPE_MAP
+
+class TestTypeLookup:
+    """Tests of _TYPE_MAP"""
+    def test_smax_to_int8(self):
+        smax_type = 'int8'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.int8
     
+    def test_smax_to_int16(self):
+        smax_type = 'int16'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.int16
+        
+    def test_smax_to_int32(self):
+        smax_type = 'int32'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.int32
+        
+    def test_smax_to_int64(self):
+        smax_type = 'int64'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.int64
+    
+    def test_smax_to_int(self):
+        smax_type = 'int'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.int32
+        
+    def test_smax_to_integer(self):
+        smax_type = 'integer'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.int32
+        
+    def test_smax_to_float32(self):
+        smax_type = 'float32'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.float32
+        
+    def test_smax_to_float64(self):
+        smax_type = 'float64'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.float64
+        
+    def test_smax_to_float(self):
+        smax_type = 'float'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.float64
+        
+    def test_smax_to_single(self):
+        smax_type = 'single'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.float32
+        
+    def test_smax_to_double(self):
+        smax_type = 'double'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == np.float64
+        
+    def test_smax_to_string(self):
+        smax_type = 'string'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == str
+        
+    def test_smax_to_str(self):
+        smax_type = 'str'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == str
+        
+    def test_smax_to_boolean(self):
+        smax_type = 'boolean'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == bool
+        
+    def test_smax_to_bool(self):
+        smax_type = 'bool'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == bool
+        
+    def test_smax_to_bytes(self):
+        smax_type = 'raw'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == bytes
+        
+class TestReverseTypeLookup:
+    """Tests of _TYPE_MAP and _REVERSE_TYPE_MAP."""
+    def test_int_to_smax(self):
+        a = 42
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int32'
+
+    def test_npint8_to_smax(self):
+        a = np.int8(42)
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int8'
+
+    def test_npint16_to_smax(self):
+        a = np.int16(42)
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int16'
+
+    def test_npint32_to_smax(self):
+        a = np.int32(42)
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int32'
+
+    def test_npint64_to_smax(self):
+        a = np.int64(42)
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int64'
+
+    def test_float_to_smax(self):
+        a = 3.141259
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'float64'
+
+    def test_float32_to_smax(self):
+        a = np.float32(3.141259)
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'float32'
+
+    def test_float64_to_smax(self):
+        a = np.float64(3.141259)
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'float64'
+
+    def test_str_to_smax(self):
+        a = 'spam'
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'string'
+        
+    def test_bool_to_smax(self):
+        a = True
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'boolean'
+        
+    def test_bytes_to_smax(self):
+        a = b'42'
+        
+        smax_type = _REVERSE_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'raw'
+
+class TestSMAXTypeLookup:
+    """Tests of _TYPE_MAP"""
+    def test_smax_to_int8(self):
+        smax_type = 'int8'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxInt8
+    
+    def test_smax_to_int16(self):
+        smax_type = 'int16'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxInt16
+        
+    def test_smax_to_int32(self):
+        smax_type = 'int32'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxInt32
+        
+    def test_smax_to_int64(self):
+        smax_type = 'int64'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxInt64
+    
+    def test_smax_to_int(self):
+        smax_type = 'int'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == np.SmaxInt32
+        
+    def test_smax_to_integer(self):
+        smax_type = 'integer'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxInt32
+        
+    def test_smax_to_float32(self):
+        smax_type = 'float32'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxFloat32
+        
+    def test_smax_to_float64(self):
+        smax_type = 'float64'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxFloat64
+        
+    def test_smax_to_float(self):
+        smax_type = 'float'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxFloat64
+        
+    def test_smax_to_single(self):
+        smax_type = 'single'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxFloat32
+        
+    def test_smax_to_double(self):
+        smax_type = 'double'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxFloat64
+        
+    def test_smax_to_string(self):
+        smax_type = 'string'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxStr
+        
+    def test_smax_to_str(self):
+        smax_type = 'str'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxStr
+        
+    def test_smax_to_boolean(self):
+        smax_type = 'boolean'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxBool
+        
+    def test_smax_to_bool(self):
+        smax_type = 'bool'
+        
+        var_type = _SMAX_TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxBool
+        
+    def test_smax_to_bytes(self):
+        smax_type = 'raw'
+        
+        var_type = _TYPE_MAP[smax_type]
+        
+        assert var_type == SmaxBytes
+
+class TestReverseSMAXTypeLookup:
+    """Tests of _SMAX_TYPE_MAP and _REVERSE_SMAX_TYPE_MAP."""
+    def test_int_to_smax(self):
+        a = SmaxInt(42)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int32'
+
+    def test_npint8_to_smax(self):
+        a = SmaxInt8(42)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int8'
+
+    def test_npint16_to_smax(self):
+        a = SmaxInt16(42)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int16'
+
+    def test_npint32_to_smax(self):
+        a = SmaxInt32(42)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int32'
+
+    def test_npint64_to_smax(self):
+        a = SmaxInt64(42)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'int64'
+
+    def test_float_to_smax(self):
+        a = SmaxFloat(3.141259)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'float64'
+
+    def test_float32_to_smax(self):
+        a = SmaxFloat32(3.141259)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'float32'
+
+    def test_float64_to_smax(self):
+        a = SmaxFloat64(3.141259)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'float64'
+
+    def test_str_to_smax(self):
+        a = SmaxStr('spam')
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'string'
+        
+    def test_bool_to_smax(self):
+        a = SmaxBool(True)
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'boolean'
+        
+    def test_bytes_to_smax(self):
+        a = SmaxBytes('42')
+        
+        smax_type = _REVERSE_SMAX_TYPE_MAP[type(a)]
+        
+        assert smax_type == 'raw'
+
 class TestSmaxFloat:
     """Tests of SmaxFloat"""
     def test_equality(self):
@@ -602,6 +989,35 @@ class TestSmaxStr:
         assert b.lower() == a.lower()
         
         assert type(b.lower()) is str
+        
+
+class TestSmaxBytes:
+    """Tests of SmaxBytes"""
+    def test_equality(self):
+        a = b"A SMA-X raw bytes"
+        b = SmaxBytes(a)
+        
+        assert a == b
+
+    def test_metadata(self):
+        a = b"A SMA-X string"
+        timestamp = datetime.datetime.fromtimestamp(100000000)
+        origin = "pytest"
+        seq = 2
+        smaxname = "test:smaxstr"
+        description = "A test SmaxStr"
+        
+        b = SmaxBytes(a, timestamp=timestamp, origin=origin, seq=seq, smaxname=smaxname, description=description)
+        
+        assert a == b
+        assert a == b.data
+        assert timestamp == b.timestamp
+        assert origin == b.origin
+        assert seq == b.seq
+        assert smaxname == b.smaxname
+        assert "raw" == b.type
+        assert 1 == b.dim
+        assert description == b.description
         
         
 class TestSmaxFloatArray:

--- a/tests/test_smax_redis_client.py
+++ b/tests/test_smax_redis_client.py
@@ -98,6 +98,21 @@ def test_roundtrip_int(smax_client):
     assert result.type == expected_type
     assert result.dim == expected_dim
     assert result.smaxname == f"{table}:{key}"
+    
+
+def test_roundtrip_bytes(smax_client):
+    expected_data = b"1 2 3 4 5 6 7 8 9"
+    expected_type = "raw"
+    expected_dim = 1
+    table = join(test_table, "test_roundtrip_raw")
+    key = "pytest"
+    smax_client.smax_share(table, key, expected_data)
+    result = smax_client.smax_pull(table, key)
+    assert result == expected_data
+    assert result.data == expected_data
+    assert result.type == expected_type
+    assert result.dim == expected_dim
+    assert result.smaxname == f"{table}:{key}"
 
 
 def test_roundtrip_bool(smax_client):


### PR DESCRIPTION
Add 'raw' SMA-X type that goes to Python bytes - this is intended as a fallback/debug type.

Rearrange _TYPE_MAP etc. so that smax-python only writes standard smax-types, and reads to numpy floats and ints by default