### PR TITLE
Fix memoryview type being returned by SmaxInt<n>.data

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.2.1"
+current_version = "1.2.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ['{major}.{minor}.{patch}']
 search = '{current_version}'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": []
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Client side python library for the [SMA Exchange (SMA-X)](https://docs.google.com/document/d/1eYbWDClKkV7JnJxv4MxuNBNV47dFXuUWu7C4Ve_YTf0/edit?usp=sharing) realtime structured database.
 
-Version 1.2.1
+Version 1.2.2
 
 - [API Documentation](https://smithsonian.github.io/smax-python/)
  

--- a/src/smax/__init__.py
+++ b/src/smax/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 from .smax_client import SmaxData, SmaxInt, SmaxFloat, SmaxBool, SmaxStr, \
     SmaxStrArray, SmaxArray, SmaxStruct, SmaxInt8, SmaxInt16, SmaxInt32, \

--- a/src/smax/smax_data_types.py
+++ b/src/smax/smax_data_types.py
@@ -397,7 +397,7 @@ class UserInt8(np.int8):
 @dataclass
 class SmaxInt8(UserInt8, SmaxVarBase):
     """Class for holding SMA-X integer objects, with their metadata"""
-    data: InitVar[np.int8]
+    data: InitVar[int | np.int8 | np.int16 | np.int32 | np.int64]
     type: str = field(kw_only=True, default='int8')
     
     def __repr__(self):
@@ -406,7 +406,11 @@ class SmaxInt8(UserInt8, SmaxVarBase):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
-        
+    
+    @property
+    def data(self):
+        return self
+    
     def asdict(self):
         dic = {'data':self}
         dic.update(asdict(self))
@@ -427,7 +431,7 @@ class UserInt16(np.int16):
 @dataclass
 class SmaxInt16(UserInt16, SmaxVarBase):
     """Class for holding SMA-X integer objects, with their metadata"""
-    data: InitVar[int | np.int8 | np.int16]
+    data: InitVar[int | np.int8 | np.int16 | np.int32 | np.int64]
     type: str = field(kw_only=True, default='int16')
     
     def __repr__(self):
@@ -436,6 +440,10 @@ class SmaxInt16(UserInt16, SmaxVarBase):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
+    
+    @property
+    def data(self):
+        return self
 
     def asdict(self):
         dic = {'data':self}
@@ -457,7 +465,7 @@ class UserInt32(np.int32):
 @dataclass
 class SmaxInt32(UserInt32, SmaxVarBase):
     """Class for holding SMA-X integer objects, with their metadata"""
-    data: InitVar[int | np.int8 | np.int16 | np.int32]
+    data: InitVar[int | np.int8 | np.int16 | np.int32 | np.int64]
     type: str = field(kw_only=True, default='int32')
     
     def __repr__(self):
@@ -466,7 +474,11 @@ class SmaxInt32(UserInt32, SmaxVarBase):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
-
+    
+    @property
+    def data(self):
+        return self
+    
     def asdict(self):
         dic = {'data':self}
         dic.update(asdict(self))
@@ -479,6 +491,10 @@ class UserInt64(np.int64):
             args = (kwargs.pop('data'),)
         x = np.int64.__new__(cls, args[0])
         return x
+    
+    @property
+    def data(self):
+        return self
     
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
@@ -496,7 +512,11 @@ class SmaxInt64(UserInt64, SmaxVarBase):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
-        
+    
+    @property
+    def data(self):
+        return self
+    
     def asdict(self):
         dic = {'data':self}
         dic.update(asdict(self))

--- a/src/smax/smax_data_types.py
+++ b/src/smax/smax_data_types.py
@@ -294,6 +294,10 @@ class UserArray(np.ndarray):
         x = np.array(initvar, dtype=dtype).view(cls).copy()
         
         return x
+    
+    @property
+    def memoryview(self):
+        return super().data
 
 @dataclass
 class SmaxArray(UserArray, SmaxVarBase):
@@ -319,7 +323,7 @@ class SmaxArray(UserArray, SmaxVarBase):
         
     def __repr__(self):
         return super().__repr__()
-    
+        
     @property    
     def data(self):
         return self
@@ -337,6 +341,10 @@ class UserFloat32(np.float32):
             args = (kwargs.pop('data'),)
         x = np.float32.__new__(cls, args[0])
         return x
+    
+    @property
+    def memoryview(self):
+        return super().data
     
 @dataclass
 class SmaxFloat32(UserFloat32, SmaxVarBase):
@@ -363,6 +371,10 @@ class UserFloat64(np.float64):
             args = (kwargs.pop('data'),)
         x = np.float64.__new__(cls, args[0])
         return x
+    
+    @property
+    def memoryview(self):
+        return super().data
     
 @dataclass
 class SmaxFloat64(UserFloat64, SmaxVarBase):
@@ -393,7 +405,12 @@ class UserInt8(np.int8):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
-        
+    
+    @property
+    def memoryview(self):
+        return super().data
+    
+    
 @dataclass
 class SmaxInt8(UserInt8, SmaxVarBase):
     """Class for holding SMA-X integer objects, with their metadata"""
@@ -427,7 +444,11 @@ class UserInt16(np.int16):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
-        
+    
+    @property
+    def memoryview(self):
+        return super().data
+    
 @dataclass
 class SmaxInt16(UserInt16, SmaxVarBase):
     """Class for holding SMA-X integer objects, with their metadata"""
@@ -461,7 +482,11 @@ class UserInt32(np.int32):
     def __eq__(self, other):
         """Pass the equality test through to the base class"""
         return super().__eq__(other)
-        
+    
+    @property
+    def memoryview(self):
+        return super().data
+    
 @dataclass
 class SmaxInt32(UserInt32, SmaxVarBase):
     """Class for holding SMA-X integer objects, with their metadata"""
@@ -493,8 +518,8 @@ class UserInt64(np.int64):
         return x
     
     @property
-    def data(self):
-        return self
+    def memoryview(self):
+        return super().data
     
     def __eq__(self, other):
         """Pass the equality test through to the base class"""

--- a/src/smax/smax_redis_client.py
+++ b/src/smax/smax_redis_client.py
@@ -553,8 +553,9 @@ class SmaxRedisClient(SmaxClient):
             table, key = normalize_pair(path[len(pubsub_prefix)+1:])
             self._logger.debug(f"Callback notification received:{message}")
             data = self.smax_pull(table, key)
-            self._logger.debug(f"Callback notification received:{data}")
-            self._logger.debug(f"{data.asdict()}")
+            self._logger.debug(f"Callback notification received:{type(data)} {data}")
+            self._logger.debug(f".data: {data.data}")
+            self._logger.debug(f"metadata {data.asdict()}")
             callback(data)
             
         def exception_handler(ex, pubsub, thread):

--- a/src/smax/smax_redis_client.py
+++ b/src/smax/smax_redis_client.py
@@ -553,6 +553,8 @@ class SmaxRedisClient(SmaxClient):
             table, key = normalize_pair(path[len(pubsub_prefix)+1:])
             self._logger.debug(f"Callback notification received:{message}")
             data = self.smax_pull(table, key)
+            self._logger.debug(f"Callback notification received:{data}")
+            self._logger.debug(f"{data.asdict()}")
             callback(data)
             
         def exception_handler(ex, pubsub, thread):

--- a/tests/test_smax_data_types.py
+++ b/tests/test_smax_data_types.py
@@ -409,6 +409,7 @@ class TestSmaxFloat:
         
         assert a == pytest.approx(b)
         assert a == pytest.approx(b.data)
+        assert type(b.data) is SmaxFloat
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -461,6 +462,7 @@ class TestSmaxFloat32:
         
         assert a == pytest.approx(b)
         assert a == pytest.approx(b.data)
+        assert type(b.data) is SmaxFloat32
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -532,6 +534,7 @@ class TestSmaxFloat64:
         
         assert a == pytest.approx(b)
         assert a == pytest.approx(b.data)
+        assert type(b.data) is SmaxFloat64
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -614,6 +617,7 @@ class TestSmaxInt:
         
         assert a == b
         assert a == b.data
+        assert type(b.data) is SmaxInt
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -668,6 +672,8 @@ class TestSmaxInt8:
         
         assert a == b
         assert a == b.data
+        # check that we don't get a memoryview object from .data
+        assert type(b.data) is SmaxInt8
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -737,6 +743,7 @@ class TestSmaxInt16:
         
         assert a == b
         assert a == b.data
+        assert type(b.data) is SmaxInt16
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -806,6 +813,7 @@ class TestSmaxInt32:
         
         assert a == b
         assert a == b.data
+        assert type(b.data) is SmaxInt32
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq
@@ -875,6 +883,7 @@ class TestSmaxInt64:
         
         assert a == b
         assert a == b.data
+        assert type(b.data) is SmaxInt64
         assert timestamp == b.timestamp
         assert origin == b.origin
         assert seq == b.seq


### PR DESCRIPTION
Numpy Ints have a property called .data, that returns a memory view of the object, rather than the object itself.  The order of inheritance in defining SmaxInt<n> led to the SmaxVarBase .data property being overwritten by this property.  It had already been fixed in SmaxFloats, but not SmaxInts.

This patches smax_data_types.py to ensure the correct .data property is returned.  A note should be added to the documentation that this overrides the numpy base .data memoryview.